### PR TITLE
Change logic for handling pinning

### DIFF
--- a/biomage/stage/stage.py
+++ b/biomage/stage/stage.py
@@ -163,11 +163,11 @@ def create_manifest(templates, token):
                 ).lower()
 
             # pin chart version if pinning is on
-            if (
-                recursive_get(document, "spec", "chart", "ref")
-                and document["spec"]["chart"]["ref"] == "STAGING_CHART_REF"
-            ):
-                if name in pins:
+            if recursive_get(document, "spec", "chart", "ref"):
+                if (
+                    name in pins
+                    and document["spec"]["chart"]["ref"] == "STAGING_CHART_REF"
+                ):
                     document["spec"]["chart"]["ref"] = get_latest_master_sha(
                         document["spec"]["chart"], token
                     )

--- a/biomage/stage/stage.py
+++ b/biomage/stage/stage.py
@@ -164,10 +164,7 @@ def create_manifest(templates, token):
 
             # pin chart version if pinning is on
             if recursive_get(document, "spec", "chart", "ref"):
-                if (
-                    name in pins
-                    and document["spec"]["chart"]["ref"] == "STAGING_CHART_REF"
-                ):
+                if name in pins:
                     document["spec"]["chart"]["ref"] = get_latest_master_sha(
                         document["spec"]["chart"], token
                     )


### PR DESCRIPTION
The `STAGING_CHART_REF` condition meant worker charts would not be pinned correctly because their CI pipeline does not replace the ref with `STAGING_CHART_REF`.