### PR TITLE
Add `experiments compare` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,11 @@ previously from [here](https://github.com/biomage-ltd/iac/tree/master/releases/s
     python3 biomage unstage my-sandbox-id
 
 to remove your deployment.
+
+### experiment
+
+#### exepriment compare
+
+Compares experiment settings accros development/staging/production environments.
+
+    python3 biomage experiment compare my-exeperiment-id

--- a/biomage/__main__.py
+++ b/biomage/__main__.py
@@ -3,6 +3,7 @@ from configure_repo import configure_repo
 from rotate_ci import rotate_ci
 from stage import stage
 from unstage import unstage
+from experiment import experiment
 
 
 @click.group()
@@ -16,7 +17,7 @@ main.add_command(configure_repo.configure_repo)
 main.add_command(rotate_ci.rotate_ci)
 main.add_command(stage.stage)
 main.add_command(unstage.unstage)
-
+main.add_command(experiment.experiment)
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ PyInquirer
 click
 cfn-flip
 anybase32
+deepdiff-5.2.3


### PR DESCRIPTION

<img width="875" alt="image" src="https://user-images.githubusercontent.com/460418/113880092-760a5800-97bb-11eb-9fb1-3ca08d2a91d3.png">

This PR adds an `experiments compare` command, that compares experiments across development/staging/production.

* The implementation is fully local, so your `aws` privileges will be used. I am wondering if this really should be implemented in the API, with a new endpoint supporting exporting experiments. The API approach comes with its own issues: dealing with authorization, what is the staging API endpoint...
* At the moment, only the `biomage-source` s3 bucket and the `experiments` dynamoDB table are compared
* I think that for problem determination once we have users with their own data, it is very likely that we will want to have the ability to clone experiments. 
* The compare uses https://zepworks.com/deepdiff. I wonder if creating JSON files and relying in `git diff --no-index` would be a wiser approach

Sample output
```
$ python biomage experiment compare 5928a56c7cbff9de78974ab50765ed20
Comparing records for table experiments
No record for experiments in ['development']
Comparing staging to production for experiments
{'dictionary_item_removed': [root['processingConfig']['dataIntegration']],
 'iterable_item_removed': {"root['processingConfig']['meta']['stepsDone'][5]": 'dataIntegration'},
 'values_changed': {"root['cellSets'][0]['children'][0]['name']": {'new_value': 'Cluster '
                                                                                '0',
                                                                   'old_value': 'cosa'},
                    "root['cellSets'][1]['children'][1]['cellIds']": {'new_value': 'Hashed_as_7050023711663492825',
                                                                      'old_value': 'Hashed_as_7684717080212037816'},
                    "root['cellSets'][1]['children'][1]['key']": {'new_value': '3a60f8c9-4d57-435f-8545-caeab5bed215',
                                                                  'old_value': '6d2fbd8f-49b2-4149-b570-4ef93bd8fc4c'},
                    "root['processingConfig']['configureEmbedding']['embeddingSettings']['methodSettings']['tsne']['learningRate']": {'new_value': Decimal('200'),
                                                                                                                                      'old_value': Decimal('100')},
                    "root['processingConfig']['configureEmbedding']['embeddingSettings']['methodSettings']['tsne']['perplexity']": {'new_value': Decimal('30'),
                                                                                                                                    'old_value': Decimal('33')},
                    "root['processingConfig']['configureEmbedding']['embeddingSettings']['methodSettings']['umap']['minimumDistance']": {'new_value': Decimal('0.6'),
                                                                                                                                         'old_value': Decimal('0.9')},
                    "root['processingConfig']['meta']['stepsDone'][3]": {'new_value': 'genesVsUMIFilter',
                                                                         'old_value': 'doubletFilter'},
                    "root['processingConfig']['meta']['stepsDone'][4]": {'new_value': 'doubletFilter',
                                                                         'old_value': 'genesVsUMIFilter'}}}
Comparing files for bucket biomage-source
Comparing development to staging for biomage-source
{'dictionary_item_added': [root[''], root['python.h5ad'], root['r.rds']]}
Comparing development to production for biomage-source
{'dictionary_item_added': [root['python.h5ad'], root['r.rds']]}
Comparing staging to production for biomage-source
{'dictionary_item_removed': [root['']],
 'values_changed': {"root['python.h5ad']['ETag']": {'new_value': '"d9f61d08e3ebd95b476441289d8ae2e3"',
                                                    'old_value': '"55f27ffb59651f54f3779a2a6720e5f4-108"'},
                    "root['python.h5ad']['LastModified']": {'new_value': '2021-01-26T18:32:22+00:00',
                                                            'old_value': '2021-02-10T16:39:43+00:00'},
                    "root['r.rds']['ETag']": {'new_value': '"fc24b27a07aeec979e277c537bec07c5"',
                                              'old_value': '"a5984301c4efae192a487846e690d134-50"'},
                    "root['r.rds']['LastModified']": {'new_value': '2021-02-16T21:52:39+00:00',
                                                      'old_value': '2021-02-18T19:08:41+00:00'}}}
``` 




