### PR TITLE
remove punctuation marks from username used to stage

### DIFF
--- a/biomage/stage/stage.py
+++ b/biomage/stage/stage.py
@@ -118,7 +118,7 @@ def get_sandbox_id(templates, manifests):
     )
 
     fragments = (
-        os.getenv("BIOMAGE_NICK", os.getenv("USER", "")),
+        re.sub(r'[^\w\s]','', os.getenv("BIOMAGE_NICK", os.getenv("USER", ""))),
         pr_ids if pr_ids else manifest_hash,
     )
     sandbox_id = "-".join([bit for bit in fragments if bit]).lower()[:26]


### PR DESCRIPTION
Having punctuation marks in the username will trigger an error when staging because the result deployment  ID will not satisfy the regex  [a-zA-Z][-a-zA-Z0-9]*|arn:[-a-zA-Z0-9:/._+]*

This commit removes any punctuation marks from the username to be used in the deployment ID.