### PR TITLE
adding clean to install step to remove venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ MKFILE_DIR := $(dir $(MKFILE_PATH))
 #--------------------------------------------------
 # Targets
 #--------------------------------------------------
-install: ## Creates venv, and adds biomage as system command
+install: clean ## Creates venv, and adds biomage as system command
 	@echo "Creating virtual env and installing dependencies..."
 	@python3 -m venv venv
 	@venv/bin/pip3 install -r requirements.txt


### PR DESCRIPTION
It seems that installing new deps sometimes created conflicts in `venv`. Added clean step before install to start from a clean slate.