### PR TITLE
upgrade pip in venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,5 +140,5 @@ dmypy.json
 cython_debug/
 
 .vscode
-
 .DS_Store
+/data

--- a/.gitignore
+++ b/.gitignore
@@ -141,4 +141,4 @@ cython_debug/
 
 .vscode
 .DS_Store
-/data
+data/

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ MKFILE_DIR := $(dir $(MKFILE_PATH))
 install: clean ## Creates venv, and adds biomage as system command
 	@echo "Creating virtual env and installing dependencies..."
 	@python3 -m venv venv
+	@venv/bin/pip3 install --upgrade pip
 	@venv/bin/pip3 install -r requirements.txt
 	@echo "    [✓]\n"
 	@echo "Installing biomage into ${INSTALL_PATH}"

--- a/README.md
+++ b/README.md
@@ -136,13 +136,13 @@ E.g. to download experiment `e52b39624588791a7889e39c617f669e` data from `produc
 
 `biomage experiment pull production e52b39624588791a7889e39c617f669e`
 
-#### experiment get
+#### experiment ls
 
-List available experiments data in a given environment. See `biomage experiment get --help` for more information, parameters and default values.
+List available experiments data in a given environment. See `biomage experiment ls --help` for more information, parameters and default values.
 
 Example: list experiment files in `production`:
 
-`biomage experiment get production`
+`biomage experiment ls production`
 
 #### experiment compare
 

--- a/biomage/experiment/pull.py
+++ b/biomage/experiment/pull.py
@@ -1,8 +1,15 @@
 import boto3
 import click
 
-from .utils import (PULL, Summary, download_S3_json, download_S3_rds,
-                    is_modified, load_cfg_file, save_cfg_file)
+from .utils import (
+    PULL,
+    Summary,
+    download_S3_json,
+    download_S3_rds,
+    is_modified,
+    load_cfg_file,
+    save_cfg_file,
+)
 
 CELLSETS_FILE = "mock_cell_sets.json"
 PLOTS_TABLES_FILE = "mock_plots_tables.json"

--- a/biomage/experiment/pull.py
+++ b/biomage/experiment/pull.py
@@ -1,15 +1,8 @@
 import boto3
 import click
 
-from .utils import (
-    PULL,
-    Summary,
-    download_S3_json,
-    download_S3_rds,
-    is_modified,
-    load_cfg_file,
-    save_cfg_file,
-)
+from .utils import (PULL, Summary, download_S3_json, download_S3_rds,
+                    is_modified, load_cfg_file, save_cfg_file)
 
 CELLSETS_FILE = "mock_cell_sets.json"
 PLOTS_TABLES_FILE = "mock_plots_tables.json"


### PR DESCRIPTION
# Background
#### Link to issue 

- Package `cryptography` fails building with Python3.8's bundled pip version 19.1. (https://stackoverflow.com/questions/61553778/why-is-my-venv-using-a-different-pip-version-than-i-have-installed).
- Package `cryptography` works for pip version 21. Therefore, pip has to be upgraded after setting up `venv`
- add `data` in `.gitignore` to ignore downloaded files

#### Link to staging deployment URL 

N.A.

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

- Force pip to update to latest version after setting up `venv`
- Updated `README.md`, replacing `experiment get` with `experiment ls`

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [X] New commands have been added to Makefile/test
- [ ] Unit tests written
- [X] Run make test
- [X] Test any modified command

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [X] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team


### Optional
- [ ] Photo of a cute animal attached to this PR
