### PR TITLE
Serialize dynamodb sets as lists to fix experiment pull

### DIFF
--- a/biomage/experiment/utils.py
+++ b/biomage/experiment/utils.py
@@ -45,10 +45,23 @@ class Summary(object):
 
 
 def save_cfg_file(dictionary, dst_file):
+    def serialize_sets(obj):
+        if isinstance(obj, set):
+            return list(obj)
+        return obj
+
     with open(os.path.join(DATA_LOCATION, dst_file), "w") as f:
         # We sort & indent the result to make it easier to inspect & debug the files
         # neither sorting nor indentation is used to check if two confis are equal
-        f.write(json.dumps(dictionary, use_decimal=True, indent=4, sort_keys=True))
+        f.write(
+            json.dumps(
+                dictionary,
+                use_decimal=True,
+                indent=4,
+                sort_keys=True,
+                default=serialize_sets,
+            )
+        )
 
 
 # If the config file was found => retun  (config file, true)


### PR DESCRIPTION
# Background
#### Link to issue 
https://this-is-biomage.slack.com/archives/C015CHSUDRU/p1620654912039700
#### Link to staging deployment URL 
N/A
#### Links to any Pull Requests related to this
N/A
#### Anything else the reviewers should know about the changes here
In our local environment, every DynamoDB set is going to be a plain `list`. Currently, this is the case only of `rbac_can_write` in the experiments table. Can be merged as soon as approved.
# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] New commands have been added to Makefile/test
- [ ] Unit tests written
- [ ] Run make test
- [ ] Test any modified command

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team


### Optional
- [ ] Photo of a cute animal attached to this PR
