### PR TITLE
checking if config files are empty to avoid weird decoding errors

### DIFF
--- a/biomage/experiment/pull.py
+++ b/biomage/experiment/pull.py
@@ -73,6 +73,8 @@ def update_config_if_needed(filepath, table_name, experiment_id):
         remote_cfg = remove_key(remote_cfg, "pipeline")
 
     # if the local config was not found or it's different from the remote => update
+    # beware that due to serializing sets into lists, the comparison will always be false
+    # for config files with sets (such as mock_experiment.json)
     if not found or local_cfg != remote_cfg:
         save_cfg_file(remote_cfg, filepath)
         Summary.add_changed_file(filepath)

--- a/biomage/experiment/utils.py
+++ b/biomage/experiment/utils.py
@@ -67,11 +67,12 @@ def save_cfg_file(dictionary, dst_file):
 # If the config file was found => retun  (config file, true)
 # Otherwise => (None, False)
 def load_cfg_file(file):
-    try:
+    filepath = os.path.join(DATA_LOCATION, file)
+    if os.path.exists(filepath) and not os.path.getsize(filepath) == 0:
         with open(os.path.join(DATA_LOCATION, file)) as f:
             return json.loads(f.read(), use_decimal=True), True
-    except FileNotFoundError:
-        return None, False
+
+    return None, False
 
 
 def set_modified_date(file_location, date):


### PR DESCRIPTION
Checking if a config file exists **and** it's not empty because having a json mock file empty triggered a weird decoding error.