### PR TITLE
staging command setting correctly reference for pinned with charts in…

### DIFF
--- a/biomage/release/release.py
+++ b/biomage/release/release.py
@@ -1,38 +1,25 @@
-import base64
-import hashlib
-import json
-import math
-import os
-import re
-from collections import namedtuple
-from functools import reduce
-
-import anybase32
-import boto3
 import click
-import requests
-import yaml
-from botocore.exceptions import ClientError
 from github import Github
 from PyInquirer import prompt
 
 REPOS = ("ui", "api", "pipeline", "worker")
 ORG = "biomage-ltd"
 
+
 def prompt_repos_to_release():
-    questions = [    {
-        "type": "checkbox",
-        "name": "repos",
-        "message": "Which repositories would you like to release?",
-        "choices": [
-            {"name": name, "checked": False}
-            for name in REPOS
-        ],
-    }    ]
+    questions = [
+        {
+            "type": "checkbox",
+            "name": "repos",
+            "message": "Which repositories would you like to release?",
+            "choices": [{"name": name, "checked": False} for name in REPOS],
+        }
+    ]
     click.echo()
     answers = prompt(questions)
 
     return answers["repos"]
+
 
 def release_confirmed(repos):
     questions = [
@@ -46,6 +33,7 @@ def release_confirmed(repos):
     answers = prompt(questions)
     return answers["create"]
 
+
 def get_release_workflow(token):
     g = Github(token)
     o = g.get_organization(ORG)
@@ -58,7 +46,8 @@ def get_release_workflow(token):
             wf = str(workflow.id)
 
     return r.get_workflow(wf)
-        
+
+
 @click.command()
 @click.option(
     "--token",
@@ -67,7 +56,7 @@ def get_release_workflow(token):
     required=True,
     help="A GitHub Personal Access Token with the required permissions.",
 )
-@click.option('--all', is_flag=True, help="Release all repositories")
+@click.option("--all", is_flag=True, help="Release all repositories")
 def release(token, all):
     """
     Creates a new release.
@@ -80,10 +69,9 @@ def release(token, all):
     if len(repos) < 1:
         click.echo("No repositories selected, exiting release process.")
         exit(1)
-    
+
     if not release_confirmed(repos):
         exit(1)
-
 
     wf = get_release_workflow(token)
 
@@ -95,7 +83,7 @@ def release(token, all):
 
         click.echo(
             click.style(
-                f"✔️ Release creation for {repo} submitted. You can check your progress at "
+                f"✔️ Release creation for {repo} submitted. Check your progress at "
                 f"https://github.com/{ORG}/iac/actions",
                 fg="green",
                 bold=True,

--- a/biomage/unstage/unstage.py
+++ b/biomage/unstage/unstage.py
@@ -5,7 +5,6 @@ import re
 import boto3
 import click
 import requests
-import yaml
 from github import Github
 from PyInquirer import prompt
 from utils.config import get_config

--- a/biomage/utils/config.py
+++ b/biomage/utils/config.py
@@ -7,7 +7,9 @@ import yaml
 def get_config():
     # Read configuration
     config = None
-    # this depends on the location of this config file, we use this to avoid depending on current working dir
+    # this depends on the location of this config file, we use this to avoid depending
+    # on the current working dir so that `biomage` cmd can be called from anywhere
+    # in the system
     repo_root = pathlib.Path(__file__).parent.parent.parent
     with open(os.path.join(repo_root, "config.yaml")) as config_file:
         config = list(yaml.load_all(config_file, Loader=yaml.SafeLoader))[0]

--- a/biomage/utils/data.py
+++ b/biomage/utils/data.py
@@ -33,8 +33,8 @@ def modified_records(item, target_table, config):
 
 def definitely_equal(target, source):
     """
-    Returns if 2 objects are equal. Only positive return values are reliable. Two objects might be equal
-    and return false due to a number of reasons like:
+    Returns if 2 objects are equal. Only positive return values are reliable. Two
+    objects might be equal and return false due to a number of reasons like:
     * We can't reliably use etags for object comparison
     * If there's any exception trying to get the target bucket, we'll just return false.
 
@@ -50,7 +50,8 @@ def definitely_equal(target, source):
         )
         same_etag = True
     except ClientError:
-        # if there's any exception assume the comparison failed a return false (which can be a false negative or a true negative)
+        # if there's any exception assume the comparison failed a return false
+        #  (which can be a false negative or a true negative)
         pass
 
     return same_etag
@@ -133,7 +134,8 @@ def copy_experiments_to(
     experiments, sandbox_id, config, origin=PRODUCTION, destination=STAGING
 ):
     """
-    Copy the list of experiment IDs in experiments from the origin env into destination env.
+    Copy the list of experiment IDs in experiments from the origin env into
+    destination env.
     """
     click.echo()
     click.echo("Copying items for new experiments...")


### PR DESCRIPTION
Staging command was creating invalid chart references for the repos which have their charts in IAC. The issue was that the function computing the chart `ref` was using the reference for the repo to be released instead of the chart repo, and thus it failed when trying to pin UI & API. 