### PR TITLE
Fix name suggestions

### DIFF
--- a/biomage/stage/stage.py
+++ b/biomage/stage/stage.py
@@ -194,7 +194,7 @@ def get_sandbox_id(templates, manifests, all_experiments):
         [
             f"{repo}{opts.ref}"
             for repo, opts in templates.items()
-            if opts.ref != "master"
+            if opts.ref != "develop"
         ]
     )
 


### PR DESCRIPTION
The proposed named included all the repos after our move from `master` to `develop`
