### PR TITLE
donwloading config files before rds

### DIFF
--- a/biomage/experiment/pull.py
+++ b/biomage/experiment/pull.py
@@ -191,6 +191,8 @@ def pull(experiment_id, input_env):
 
     Summary.set_command(cmd=PULL, origin=input_env, experiment_id=experiment_id)
 
+    update_configs(experiment_id, input_env)
+
     bucket = f"biomage-source-{input_env}"
     remote_file = f"{experiment_id}/r.rds"
     local_file = f"{experiment_id}/{SOURCE_RDS_FILE}.gz"
@@ -205,7 +207,5 @@ def pull(experiment_id, input_env):
     local_file = f"{experiment_id}/{CELLSETS_FILE}"
     # the name of the cell sets file in S3 is just the experiment ID
     download_if_modified(bucket=bucket, key=experiment_id, filepath=local_file)
-
-    update_configs(experiment_id, input_env)
 
     Summary.report_changes()

--- a/biomage/experiment/utils.py
+++ b/biomage/experiment/utils.py
@@ -48,7 +48,12 @@ class Summary(object):
 
 
 def save_cfg_file(dictionary, dst_file):
-    with open(os.path.join(DATA_LOCATION, dst_file), "w") as f:
+    local_file = os.path.join(DATA_LOCATION, dst_file)
+
+    # try to create experiment folder, ignores if already exists (same as mkdir -p)
+    Path(os.path.dirname(local_file)).mkdir(parents=True, exist_ok=True)
+
+    with open(local_file, "w") as f:
         # We sort & indent the result to make it easier to inspect & debug the files
         # neither sorting nor indentation is used to check if two confis are equal
         json.dump(dictionary, f)


### PR DESCRIPTION
I just changed the order in which `experiment pull` download data. It used to first get the rds files and then dynamoDB tables. Now it's the other way around so you can have a look at the json config files while rds are being downloaded.
