### PR TITLE
Don't crash if experiment id is not found

### DIFF
--- a/biomage/utils/data.py
+++ b/biomage/utils/data.py
@@ -64,6 +64,10 @@ def copy_s3_files(sandbox_id, prefix, source_bucket, target_bucket):
     s3 = boto3.client("s3")
     exp_files = s3.list_objects_v2(Bucket=source_bucket, Prefix=prefix)
 
+    if 'Contents' not in exp_files:
+        click.echo(f"Failed to do an experiment copy: bucket {source_bucket} doesn't contain {prefix} as prefix.")
+        return
+    
     for obj in exp_files.get("Contents"):
 
         experiment_id = obj["Key"].split("/")[0]

--- a/biomage/utils/data.py
+++ b/biomage/utils/data.py
@@ -65,8 +65,7 @@ def copy_s3_files(sandbox_id, prefix, source_bucket, target_bucket):
     exp_files = s3.list_objects_v2(Bucket=source_bucket, Prefix=prefix)
 
     if 'Contents' not in exp_files:
-        click.echo(f"Failed to do an experiment copy: bucket {source_bucket} doesn't contain {prefix} as prefix.")
-        return
+        raise Exception(f"Failed to do an experiment copy: bucket {source_bucket} doesn't contain {prefix} as prefix.")
     
     for obj in exp_files.get("Contents"):
 


### PR DESCRIPTION
# Background
I tried to do biomage copy and mistyped the experiment id, which lead to the code blowing up, because it expects to always find an experiment id. So I added this little if statement to guard against that.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] New commands have been added to Makefile/test
- [ ] Unit tests written
- [ ] Run make test
- [ ] Test any modified command

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team


### Optional
- [ ] Photo of a cute animal attached to this PR
