### PR TITLE
Fixes

### DIFF
--- a/biomage/experiment/ls.py
+++ b/biomage/experiment/ls.py
@@ -15,7 +15,6 @@ def list_bucket_files(bucket):
 @click.argument(
     "origin",
     default=PRODUCTION,
-    show_default=True,
 )
 def ls(origin):
     """

--- a/biomage/stage/stage.py
+++ b/biomage/stage/stage.py
@@ -273,11 +273,11 @@ def create_manifest(templates, token, repo_to_ref, all_experiments, auto):
         )
         click.echo(
             "The sandbox will not be affected by any future changes made to pinned "
-            "deployments. For example, if you pin `ui`,",
+            "deployments. For example, if you pin `ui`, \n"
             f"no new changes made to the {DEFAULT_BRANCH} branch of the `ui` "
-            "repository will propagate to your sandbox after it’s created.",
+            "repository will propagate to your sandbox after it’s created.\n"
             f"By default, only deployments sourced from the {DEFAULT_BRANCH} "
-            "are pinned, deployments using branches you are",
+            "are pinned, deployments using branches you are "
             "likely to be testing (e.g. pull requests) are not.",
         )
         questions = [

--- a/biomage/stage/stage.py
+++ b/biomage/stage/stage.py
@@ -549,6 +549,7 @@ def select_staging_experiments(sandbox_id, all_experiments, config):
     "--auto",
     is_flag=True,
     default=False,
+    show_default=True,
     help="Set auto flag to use default staging options without requiring any"
     " user input. It will pin the default branches, generate a random name for"
     " the sandbox, and will not stage any experiment data.",


### PR DESCRIPTION
The @argument s in click do not support `show_default`. The formatting suggested for `click.echo` endlines breaks with: 


```
Traceback (most recent call last):
  File "/usr/local/bin/biomage", line 33, in <module>
    sys.exit(load_entry_point('biomage-utils', 'console_scripts', 'biomage')())
  File "/Users/ahriman/repos/github.com/biomage-ltd/biomage-utils/venv/lib/python3.9/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/Users/ahriman/repos/github.com/biomage-ltd/biomage-utils/venv/lib/python3.9/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/Users/ahriman/repos/github.com/biomage-ltd/biomage-utils/venv/lib/python3.9/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/ahriman/repos/github.com/biomage-ltd/biomage-utils/venv/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/ahriman/repos/github.com/biomage-ltd/biomage-utils/venv/lib/python3.9/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/Users/ahriman/repos/github.com/biomage-ltd/biomage-utils/biomage/stage/stage.py", line 569, in stage
    manifest, sandbox_id = create_manifest(
  File "/Users/ahriman/repos/github.com/biomage-ltd/biomage-utils/biomage/stage/stage.py", line 274, in create_manifest
    click.echo(
  File "/Users/ahriman/repos/github.com/biomage-ltd/biomage-utils/venv/lib/python3.9/site-packages/click/utils.py", line 298, in echo
    file.write(out)  # type: ignore
AttributeError: 'str' object has no attribute 'write'
```