### PR TITLE
Update sample copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Example: list experiment files in `production`:
 
 #### experiment copy
 
-Copies one experiment information from a given env to another, prefxing keys of the copied data and records with `sandbox_id`. It is recommended to set the value of `sandbox_id` to the same value as your staging environment, so that running `biomage unstage` when unstaging the experiment will also delete records of the copied experiment.
+Copies one experiment information from a given env to another (default: production to staging), prefxing keys of the copied data and records with `sandbox_id`. It is recommended to set the value of `sandbox_id` to the same value as your staging environment, so that running `biomage unstage` when unstaging the experiment will also delete records of the copied experiment.
 
 To run this command, `BIOMAGE_EMAIL` has to be set with the username you use to login in the staging environment. See `biomage experiment copy --help` for more details.
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Downloads experiment data and config files from a given environment into `BIOMAG
 
 E.g. to download experiment `e52b39624588791a7889e39c617f669e` data from `production`:
 
-`biomage experiment pull production e52b39624588791a7889e39c617f669e`
+    biomage experiment pull production e52b39624588791a7889e39c617f669e
 
 #### experiment ls
 
@@ -170,7 +170,15 @@ List available experiments data in a given environment. See `biomage experiment 
 
 Example: list experiment files in `production`:
 
-`biomage experiment ls production`
+    biomage experiment ls production
+
+#### experiment copy
+
+Copies one experiment information from a given env to another, prefxing keys of the copied data and records with `sandbox_id`. It is recommended to set the value of `sandbox_id` to the same value as your staging environment, so that running `biomage unstage` when unstaging the experiment will also delete records of the copied experiment.
+
+To run this command, `BIOMAGE_EMAIL` has to be set with the username you use to login in the staging environment. See `biomage experiment copy --help` for more details.
+
+    biomage experiment copy --experiment_id=my-experiment-id --sandbox_id=my-sandbox-id
 
 #### experiment compare
 
@@ -184,11 +192,3 @@ Creates new releases from develop branches.
 
 `biomage release` -> creates a new release asking for systems to be released.
 `biomage release --all` -> creates a new release for all repos (ui, api, pipeline, worker).
-
-#### experiment copy
-
-Copies one experiment information from a given env to another, prefxing keys of the copied data and records with `sandbox_id`. It is recommended to set the value of `sandbox_id` to the same value as your staging environment, so that running `biomage unstage` when unstaging the experiment will also delete records of the copied experiment.
-
-To run this command, `BIOMAGE_EMAIL` has to be set with the username you use to login in the staging environment. See `biomage experiment copy --help` for more details.
-
-`biomage experiment copy --experiment_id=e52b39624588791a7889e39c617f669e --sandbox_id=default`

--- a/biomage/experiment/utils.py
+++ b/biomage/experiment/utils.py
@@ -158,19 +158,30 @@ def create_gem2s_hash(experiment, project, samples):
     if experiment['meta']['M']['organism'].get('S'):
         organism = experiment['meta']['M']['organism']['S']
 
-    sample_ids = [sample_id for sample_id in samples['M']]
+    # Filter 'ids' key which is present in older samples object
+    unsorted_sample_ids = [
+        sample_id
+        for sample_id
+        in samples['M']
+        if sample_id != 'ids'
+    ]
+
+    # Sample IDS is first sorted so that hash does not depend on order of samples
+    sorted_sample_ids = unsorted_sample_ids.copy()
+    sorted_sample_ids.sort()
 
     sample_names = []
-    for sample_id in sample_ids:
+
+    # Sample names are created according to the sorted sampleIds so sample order doesn't matter
+    for sample_id in sorted_sample_ids:
         sample_names.append(samples['M'][sample_id]['M']['name']['S'])
 
-    sample_ids.sort()
-    sample_names.sort()
+    hash_params = OrderedDict()
 
     hash_params = {
         "organism": organism,
         "input": {"type" : experiment["meta"]['M']["type"]["S"]},
-        "sampleIds": sample_ids,
+        "sampleIds": sorted_sample_ids,
         "sampleNames": sample_names,
     }
 
@@ -178,11 +189,12 @@ def create_gem2s_hash(experiment, project, samples):
     metadata_keys = [metadata['S'] for metadata in project['M']['metadataKeys']['L']]
 
     if len(metadata_keys) > 0:
+
         for key in metadata_keys:
             # Replace '-' in key to '_'if
             sanitizedKey = key.replace('-', '_')
 
-            for sample_id in sample_ids:
+            for sample_id in unsorted_sample_ids:
 
                 metadata_value = constants.DEFAULT_METADATA_VALUE
 
@@ -196,7 +208,10 @@ def create_gem2s_hash(experiment, project, samples):
 
         hash_params['metadata'] = metadata_values
 
-    hash_params_string = json.dumps(hash_params).replace(", ", ",").replace(": ", ":").encode('utf-8')
+    hash_params_string = json.dumps(hash_params) \
+        .replace(", ", ",") \
+        .replace(": ", ":") \
+        .encode('utf-8')
 
     return hashlib.sha1(hash_params_string).hexdigest()
 

--- a/biomage/experiment/utils.py
+++ b/biomage/experiment/utils.py
@@ -159,11 +159,9 @@ def create_gem2s_hash(experiment, project, samples):
         organism = experiment['meta']['M']['organism']['S']
 
     # Filter 'ids' key which is present in older samples object
-    unsorted_sample_ids = [
-        sample_id
-        for sample_id
-        in samples['M']
-        if sample_id != 'ids'
+    unsorted_sample_ids = [ 
+        sample_id for sample_id
+        in samples['M'] if sample_id != 'ids'
     ]
 
     # Sample IDS is first sorted so that hash does not depend on order of samples

--- a/biomage/experiment/utils.py
+++ b/biomage/experiment/utils.py
@@ -164,9 +164,10 @@ def create_gem2s_hash(experiment, project, samples):
     for sample_id in sample_ids:
         sample_names.append(samples['M'][sample_id]['M']['name']['S'])
 
-    task_params = {
-        "projectId": experiment['projectId']['S'],
-        "experimentName": experiment['experimentName']['S'],
+    sample_ids.sort()
+    sample_names.sort()
+
+    hash_params = {
         "organism": organism,
         "input": {"type" : experiment["meta"]['M']["type"]["S"]},
         "sampleIds": sample_ids,
@@ -193,11 +194,11 @@ def create_gem2s_hash(experiment, project, samples):
 
                 metadata_values[sanitizedKey].append(metadata_value)
 
-        task_params['metadata'] = metadata_values
+        hash_params['metadata'] = metadata_values
 
-    task_params_string = json.dumps(task_params).replace(", ", ",").replace(": ", ":").encode('utf-8')
+    hash_params_string = json.dumps(hash_params).replace(", ", ",").replace(": ", ":").encode('utf-8')
 
-    return hashlib.sha1(task_params_string).hexdigest()
+    return hashlib.sha1(hash_params_string).hexdigest()
 
 
 def add_user_to_rbac(user_name, cfg):

--- a/biomage/rotate_ci/rotate_ci.py
+++ b/biomage/rotate_ci/rotate_ci.py
@@ -9,7 +9,7 @@ import requests
 from botocore.config import Config
 from github import Github
 
-from ..utils import encrypt
+from ..utils.encrypt import encrypt
 
 config = Config(
     region_name="eu-west-1",

--- a/biomage/utils/data.py
+++ b/biomage/utils/data.py
@@ -83,12 +83,6 @@ def copy_s3_files(sandbox_id, prefix, source_bucket, target_bucket):
         experiment_id = obj["Key"].split("/")[0]
         target_key = obj["Key"].replace(experiment_id, f"{sandbox_id}-{experiment_id}")
 
-        # biomage-originals- uses projectId/sampleId/file schema,
-        # so sampleId has to be prefixed too
-        if 'biomage-originals-' in target_bucket:
-            sample_id = obj["Key"].split("/")[1]
-            target_key = target_key.replace(sample_id, f"{sandbox_id}-{sample_id}")
-
         source = {"Bucket": source_bucket, "Key": obj["Key"]}
 
         target = {


### PR DESCRIPTION
# Background
#### Link to issue 

The way gem2s params is calculated is changed in API PR 188. This PR updates the mechanism accordingly.

#### Link to staging deployment URL 

N.A.

#### Links to any Pull Requests related to this

https://github.com/biomage-ltd/api/pull/188

#### Anything else the reviewers should know about the changes here

To test : 
- Get an experiment from production that you want to copy. Note the experiment id.
- Setup a staging environment
- Run `biomage experiment copy -e {experiment_id}`
- Once the copying is done, open your staging environment. Find the copied project
- Clicking "Launch Analysis" should not re-run GEM2S.

Note : 
Currently there is a 5GB limit of the file that we can copy. This due to the limitation of the `copy_object`  method that we use (https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html). Amazon recommends the use of multipart uploads to copy larger files : https://docs.aws.amazon.com/AmazonS3/latest/userguide/CopyingObjectsMPUapi.html. This is not implemented in this ticket.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] New commands have been added to Makefile/test
- [ ] Unit tests written
- [X] Run make test
- [X] Test any modified command

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team


### Optional
- [ ] Photo of a cute animal attached to this PR
