### PR TITLE
Experiment copy updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,12 @@ then simply do:
   as the first part of the name of the staging environments created by you:
   `${BIOMAGE_NICK:-${USER}}-...`.
 
-* `BIOMAGE_EMAIL` is used by the `experiment pull` command to automatically add permissions for the downloaded experiment.
-You should specify the email used to log in into the platform in staging.
+* `BIOMAGE_EMAIL` is used by the `experiment pull/copy` command to automatically add permissions for the downloaded experiment.
+You should specify the email used to log in into the platform in staging. **Note** your current aws account will need permissions
+for cognito.
+
+* `BIOMAGE_USERNAME` is used by the `experiment pull/copy` command to automatically add permissions for the downloaded experiment.
+You should specify the user ID you can find in cognito.
 
 *  `BIOMAGE_DATA_PATH`: where to get the experiment data to populate inframock's S3 and DynamoDB. It is recommended
 to place it outside any other repositories to avoid interactions with git. For example, `export BIOMAGE_DATA_PATH=$HOME/biomage-data` (or next to where your biomage repos live). If this is not set, it will default to `./data`. **Note**: this should be permanently added to your environment (e.g. in `.zshrc`, `.localrc` or similar) because other services like `inframock` or `worker` rely on using the same path.

--- a/README.md
+++ b/README.md
@@ -57,9 +57,6 @@ then simply do:
 You should specify the email used to log in into the platform in staging. **Note** your current aws account will need permissions
 for cognito.
 
-* `BIOMAGE_USERNAME` is used by the `experiment pull/copy` command to automatically add permissions for the downloaded experiment.
-You should specify the user ID you can find in cognito.
-
 *  `BIOMAGE_DATA_PATH`: where to get the experiment data to populate inframock's S3 and DynamoDB. It is recommended
 to place it outside any other repositories to avoid interactions with git. For example, `export BIOMAGE_DATA_PATH=$HOME/biomage-data` (or next to where your biomage repos live). If this is not set, it will default to `./data`. **Note**: this should be permanently added to your environment (e.g. in `.zshrc`, `.localrc` or similar) because other services like `inframock` or `worker` rely on using the same path.
 
@@ -180,7 +177,7 @@ Example: list experiment files in `production`:
 
 Copies one experiment information from a given env to another (default: production to staging), prefxing keys of the copied data and records with `sandbox_id`. It is recommended to set the value of `sandbox_id` to the same value as your staging environment, so that running `biomage unstage` when unstaging the experiment will also delete records of the copied experiment.
 
-To run this command, `BIOMAGE_EMAIL` has to be set with the username you use to login in the staging environment. See `biomage experiment copy --help` for more details.
+To run this command, `BIOMAGE_EMAIL` has to be set with the email you use to login in the staging environment. See `biomage experiment copy --help` for more details.
 
     biomage experiment copy --experiment_id=my-experiment-id --sandbox_id=my-sandbox-id
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ then simply do:
   `${BIOMAGE_NICK:-${USER}}-...`.
 
 * `BIOMAGE_EMAIL` is used by the `experiment pull/copy` command to automatically add permissions for the downloaded experiment.
-You should specify the email used to log in into the platform in staging. **Note** your current aws account will need permissions
-for cognito.
+You should specify the email used to log in into the platform in staging. **Note** your current AWS account will need permissions
+for Cognito.
 
 *  `BIOMAGE_DATA_PATH`: where to get the experiment data to populate inframock's S3 and DynamoDB. It is recommended
 to place it outside any other repositories to avoid interactions with git. For example, `export BIOMAGE_DATA_PATH=$HOME/biomage-data` (or next to where your biomage repos live). If this is not set, it will default to `./data`. **Note**: this should be permanently added to your environment (e.g. in `.zshrc`, `.localrc` or similar) because other services like `inframock` or `worker` rely on using the same path.

--- a/biomage/experiment/copy.py
+++ b/biomage/experiment/copy.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import click

--- a/biomage/experiment/copy.py
+++ b/biomage/experiment/copy.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 import click
@@ -16,12 +17,12 @@ from ..utils.data import copy_experiments_to
     help="Experiment ID to be copied.",
 )
 @click.option(
-    "-s",
-    "--sandbox_id",
-    required=True,
-    default=DEFAULT_SANDBOX,
+    "-p",
+    "--prefix",
+    required=False,
+    default=os.getenv("BIOMAGE_EMAIL"),
     show_default=True,
-    help="Sandbox ID in the destination environment to copy the data to.",
+    help="Prefix added to copied experiment to avoid ID clashes with other copies.",
 )
 @click.option(
     "-i",
@@ -39,7 +40,16 @@ from ..utils.data import copy_experiments_to
     show_default=True,
     help="Output environment to copy the data to.",
 )
-def copy(experiment_id, sandbox_id, input_env, output_env):
+@click.option(
+    "--update_hash",
+    required=False,
+    default=True,
+    show_default=True,
+    help="When adding prefixes the experiment parameters' hash will change "
+    "so the pipeline will need to be run again. Set to true to update experiment"
+    " hash so that the pipeline does not need to run again.",
+)
+def copy(experiment_id, prefix, input_env, output_env, update_hash):
     """
     Copy an experiment from the default sandbox of the input environment into the
     sandbox_id of the output environment.
@@ -55,8 +65,9 @@ def copy(experiment_id, sandbox_id, input_env, output_env):
 
     copy_experiments_to(
         experiments=experiments,
-        sandbox_id=sandbox_id,
+        prefix=prefix,
         config=config,
         origin=input_env,
         destination=output_env,
+        update_hash=update_hash,
     )

--- a/biomage/experiment/copy.py
+++ b/biomage/experiment/copy.py
@@ -42,16 +42,7 @@ from ..utils.data import copy_experiments_to
     show_default=True,
     help="Output environment to copy the data to.",
 )
-@click.option(
-    "--update_hash",
-    required=False,
-    default=True,
-    show_default=True,
-    help="When adding prefixes the experiment parameters' hash will change "
-    "so the pipeline will need to be run again. Set to true to update experiment"
-    " hash so that the pipeline does not need to run again.",
-)
-def copy(experiment_id, prefix, input_env, output_env, update_hash):
+def copy(experiment_id, prefix, input_env, output_env):
     """
     Copy an experiment from the default sandbox of the input environment into the
     sandbox_id of the output environment.
@@ -71,5 +62,4 @@ def copy(experiment_id, prefix, input_env, output_env, update_hash):
         config=config,
         origin=input_env,
         destination=output_env,
-        update_hash=update_hash,
     )

--- a/biomage/experiment/copy.py
+++ b/biomage/experiment/copy.py
@@ -4,7 +4,7 @@ import sys
 import click
 
 from ..utils.config import get_config
-from ..utils.constants import DEFAULT_SANDBOX, PRODUCTION, STAGING
+from ..utils.constants import PRODUCTION, STAGING
 from ..utils.data import copy_experiments_to
 
 
@@ -15,16 +15,6 @@ from ..utils.data import copy_experiments_to
     required=True,
     show_default=True,
     help="Experiment ID to be copied.",
-)
-@click.option(
-    "-p",
-    "--prefix",
-    required=False,
-    default=os.getenv("BIOMAGE_EMAIL").split("@")[
-        0
-    ],  # keep only the name as @ is not allowed in DynamoDB keys
-    show_default=True,
-    help="Prefix added to copied experiment to avoid ID clashes with other copies.",
 )
 @click.option(
     "-i",
@@ -42,10 +32,9 @@ from ..utils.data import copy_experiments_to
     show_default=True,
     help="Output environment to copy the data to.",
 )
-def copy(experiment_id, prefix, input_env, output_env):
+def copy(experiment_id, input_env, output_env):
     """
-    Copy an experiment from the default sandbox of the input environment into the
-    sandbox_id of the output environment.
+    Copy an experiment from the input environment into an output environment.
     """
 
     if output_env == PRODUCTION:
@@ -58,7 +47,6 @@ def copy(experiment_id, prefix, input_env, output_env):
 
     copy_experiments_to(
         experiments=experiments,
-        prefix=prefix,
         config=config,
         origin=input_env,
         destination=output_env,

--- a/biomage/experiment/utils.py
+++ b/biomage/experiment/utils.py
@@ -1,13 +1,10 @@
 import gzip
-import hashlib
 import json
 import os
 import time
-from collections import OrderedDict
 from pathlib import Path
 
 import boto3
-from biomage.utils import constants
 
 from ..utils.constants import COGNITO_STAGING_POOL
 

--- a/biomage/experiment/utils.py
+++ b/biomage/experiment/utils.py
@@ -154,27 +154,22 @@ def add_user_to_rbac(user_name, cfg):
     if "rbac_can_write" in cfg:
         if user_name not in cfg["rbac_can_write"]["SS"]:
             cfg["rbac_can_write"]["SS"].append(user_name)
-        return cfg
     for val in cfg.values():
         if isinstance(val, dict):
             add_user_to_rbac(user_name, val)
 
 
 def add_env_user_to_experiment(cfg):
-    # get the user ID directly from an ENV variable
-    user_name = os.getenv("BIOMAGE_USERNAME")
-    if not user_name:
-        # if we didnt' get the username directly try to get it from cognito
-        # it requires aws permissions
-        email = os.getenv("BIOMAGE_EMAIL")
-        if not email:
-            raise ValueError(
-                "biomage username/ email not available to patch experiment permissions."
-                + ' Set the either environment variable "BIOMAGE_EMAIL" with the email'
-                + ' you use to log in into cellscope or the "BIOMAGE_USERNAME" with '
-                + "your ID and try again."
-            )
+    email = os.getenv("BIOMAGE_EMAIL")
+    if not email:
+        raise ValueError(
+            "biomage email not available to patch experiment permissions."
+            + ' Set the environment variable "BIOMAGE_EMAIL" with the email you use to log in into cellscope'
+            + " and try again."
+        )
 
-        user_name = get_cognito_username(email=email)
+    user_name = get_cognito_username(email=email)
 
-    return add_user_to_rbac(user_name=user_name, cfg=cfg)
+    add_user_to_rbac(user_name=user_name, cfg=cfg)
+
+    return cfg

--- a/biomage/experiment/utils.py
+++ b/biomage/experiment/utils.py
@@ -150,59 +150,6 @@ def get_experiment_project_id(experiment_id, source_table):
     return project_id
 
 
-def create_gem2s_hash(experiment, project, samples):
-
-    organism = constants.DEFAULT_NULL_SPECIES_VALUE
-
-    if experiment["meta"]["M"]["organism"].get("S"):
-        organism = experiment["meta"]["M"]["organism"]["S"]
-
-    sample_ids = [sample_id for sample_id in samples["M"]]
-
-    sample_names = []
-    for sample_id in sample_ids:
-        sample_names.append(samples["M"][sample_id]["M"]["name"]["S"])
-
-    task_params = {
-        "projectId": experiment["projectId"]["S"],
-        "experimentName": experiment["experimentName"]["S"],
-        "organism": organism,
-        "input": {"type": experiment["meta"]["M"]["type"]["S"]},
-        "sampleIds": sample_ids,
-        "sampleNames": sample_names,
-    }
-
-    metadata_values = OrderedDict()
-    metadata_keys = [metadata["S"] for metadata in project["M"]["metadataKeys"]["L"]]
-
-    if len(metadata_keys) > 0:
-        for key in metadata_keys:
-            # Replace '-' in key to '_'if
-            sanitizedKey = key.replace("-", "_")
-
-            for sample_id in sample_ids:
-
-                metadata_value = constants.DEFAULT_METADATA_VALUE
-
-                if samples["M"][sample_id]["M"]["metadata"]["M"].get(key):
-                    metadata_value = samples["M"][sample_id]["M"]["metadata"]["M"][key][
-                        "S"
-                    ]
-
-                if not metadata_values.get(sanitizedKey):
-                    metadata_values[sanitizedKey] = []
-
-                metadata_values[sanitizedKey].append(metadata_value)
-
-        task_params["metadata"] = metadata_values
-
-    task_params_string = (
-        json.dumps(task_params).replace(", ", ",").replace(": ", ":").encode("utf-8")
-    )
-
-    return hashlib.sha1(task_params_string).hexdigest()
-
-
 def add_user_to_rbac(user_name, cfg):
     if "rbac_can_write" in cfg:
         if user_name not in cfg["rbac_can_write"]["SS"]:

--- a/biomage/utils/constants.py
+++ b/biomage/utils/constants.py
@@ -4,7 +4,6 @@ STAGING = "staging"
 PRODUCTION = "production"
 
 # Default values used by biomage-utils
-DEFAULT_SANDBOX = "default"
 DEFAULT_EXPERIMENT_ID = "e52b39624588791a7889e39c617f669e"
 DEFAULT_NULL_SPECIES_VALUE = None
 DEFAULT_METADATA_VALUE = "N.A."
@@ -24,4 +23,3 @@ EXPERIMENTS_TABLE = "experiments"
 PROJECTS_TABLE = "projects"
 
 COGNITO_STAGING_POOL = "eu-west-1_sVQL15Yxu"
-

--- a/biomage/utils/data.py
+++ b/biomage/utils/data.py
@@ -38,7 +38,7 @@ def definitely_equal(target, source):
 def copy_s3_bucket(prefix, source_bucket, target_bucket):
     """
     Copy s3 files in a bucket under a prefix. Prefix is normally an experiment or
-     project id
+    project id
     """
     s3 = boto3.client("s3")
     exp_files = s3.list_objects_v2(Bucket=source_bucket, Prefix=prefix)
@@ -80,7 +80,6 @@ def copy_s3_bucket(prefix, source_bucket, target_bucket):
 def copy_s3_data(experiments, config, origin, destination):
     buckets = config["source-buckets"]
     for experiment_id in experiments:
-
         for source_bucket in buckets:
             target_bucket = source_bucket.replace(origin, destination)
 


### PR DESCRIPTION
# Changes
### Code changes

I removed the `sandbox_id` prefix feature from the `experiment copy` because it was breaking often due to relying on objects' structure.
Also removed the function updating the gem2s hash because it is no longer needed (actually recomputing the hash had the opposite effect of forcing to run the pipeline again because the hash is no longer computed as `utils` thought).
I refactored a bit the `s3` & `dynamodb` copies because they had a weird structure of nested loops. Now, the loops are: for each experiment -> for each bucket / table.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] New commands have been added to Makefile/test
- [x] Run make test
- [x] Test any modified command

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team


### Optional
- [x] Photo of a cute animal attached to this PR

![image](https://user-images.githubusercontent.com/2961095/130417414-e328d2c3-e6a9-42da-a04a-9f288a982918.png)
